### PR TITLE
Add workflow_dispatch trigger to enable manual workflow runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  workflow_dispatch:
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
This allows users to manually trigger the Playwright test workflow
from the GitHub Actions UI using the "Run workflow" button.